### PR TITLE
Fix append() and duration

### DIFF
--- a/src/MpegAudio.php
+++ b/src/MpegAudio.php
@@ -436,6 +436,7 @@ namespace falahati\PHPMP3 {
 					}
 				}
 				$this->insert($data, $endOfStream);
+				$this->analyze();
 			}
 			return $this;
 		}


### PR DESCRIPTION
Hi, and many thanks.

I discovered that $audio->append() was not handling duration at all.  This one-liner addition calls analyze() to resolve that.

There may be better ways, but this works.


Cheers,
Steve.